### PR TITLE
Define all stacks for buildpack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -297,4 +297,10 @@ api = "0.7"
       uri = "https://github.com/cloudfoundry/java-buildpack-support/blob/main/LICENSE"
 
 [[stacks]]
+  id = "io.buildpacks.stacks.bionic"
+
+[[stacks]]
+  id = "io.paketo.stacks.tiny"
+
+[[stacks]]
   id = "*"


### PR DESCRIPTION
## Summary
Apache TomEE was added to Java buildpack in https://github.com/paketo-buildpacks/java/pull/574, but some stack definitions in `buildpack.toml` are missing. Now build of Java project ends with message
```
ERROR: failed to build: validating stack mixins: buildpack paketo-buildpacks/apache-tomee@1.0.0 does not support stack io.buildpacks.stacks.bionic
```
## Use Cases

## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).