### PR TITLE
Switch to buildpackless builder

### DIFF
--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -68,18 +68,19 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 				WithVerbose().
 				Build.
 				WithPullPolicy("if-not-present").
-				WithBuilder("paketobuildpacks/builder:base").
-				WithBuildpacks("paketo-buildpacks/syft",
-					"paketo-buildpacks/ca-certificates@3.0.2",
-					"paketo-buildpacks/bellsoft-liberica",
-					"paketo-buildpacks/maven",
+				WithBuilder("paketobuildpacks/builder:buildpackless-base").
+				WithBuildpacks("gcr.io/paketo-buildpacks/ca-certificates",
+					"gcr.io/paketo-buildpacks/bellsoft-liberica",
+					"gcr.io/paketo-buildpacks/syft",
+					"gcr.io/paketo-buildpacks/maven",
 					buildpack).
 				WithEnv(map[string]string{
-					"BP_JAVA_APP_SERVER": "tomee",
-					"BP_MAVEN_BUILT_ARTIFACT": "test-jaxrs-tomee/target/*.war",
-					"BP_MAVEN_BUILT_MODULE": "test-jaxrs-tomee",
+					"BP_JAVA_APP_SERVER":       "tomee",
+					"BP_MAVEN_BUILT_ARTIFACT":  "test-jaxrs-tomee/target/*.war",
+					"BP_MAVEN_BUILT_MODULE":    "test-jaxrs-tomee",
 					"BP_MAVEN_BUILD_ARGUMENTS": "-Dmaven.test.skip=true package --no-transfer-progress",
 				}).
+				WithTrustBuilder().
 				Execute(name, source)
 			Expect(err).ToNot(HaveOccurred(), logs.String)
 
@@ -104,24 +105,25 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 				WithVerbose().
 				Build.
 				WithPullPolicy("if-not-present").
-				WithBuilder("paketobuildpacks/builder:tiny").
-				WithBuildpacks("paketo-buildpacks/syft",
-					"paketo-buildpacks/ca-certificates@3.0.2",
-					"paketo-buildpacks/bellsoft-liberica",
-					"paketo-buildpacks/maven",
+				WithBuilder("paketobuildpacks/builder:buildpackless-tiny").
+				WithBuildpacks("gcr.io/paketo-buildpacks/ca-certificates",
+					"gcr.io/paketo-buildpacks/bellsoft-liberica",
+					"gcr.io/paketo-buildpacks/syft",
+					"gcr.io/paketo-buildpacks/maven",
 					buildpack).
 				WithEnv(map[string]string{
-					"BP_JAVA_APP_SERVER": "tomee",
-					"BP_MAVEN_BUILT_ARTIFACT": "test-jaxrs-tomee/target/*.war",
-					"BP_MAVEN_BUILT_MODULE": "test-jaxrs-tomee",
+					"BP_JAVA_APP_SERVER":       "tomee",
+					"BP_MAVEN_BUILT_ARTIFACT":  "test-jaxrs-tomee/target/*.war",
+					"BP_MAVEN_BUILT_MODULE":    "test-jaxrs-tomee",
 					"BP_MAVEN_BUILD_ARGUMENTS": "-Dmaven.test.skip=true package --no-transfer-progress",
 				}).
+				WithTrustBuilder().
 				Execute(name, source)
 			Expect(err).ToNot(HaveOccurred(), logs.String)
 
 			container, err = docker.Container.Run.
 				WithEnv(map[string]string{
-					"PORT": "8080",
+					"PORT":                             "8080",
 					"BPL_TOMEE_ACCESS_LOGGING_ENABLED": "true",
 				}).
 				WithPublish("8080").

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -2,11 +2,12 @@ package integration_test
 
 import (
 	"fmt"
-	"github.com/paketo-buildpacks/occam/packagers"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/paketo-buildpacks/occam/packagers"
 
 	"github.com/BurntSushi/toml"
 	"github.com/onsi/gomega/format"
@@ -18,10 +19,8 @@ import (
 )
 
 var (
-	buildpack          string
-	//buildPlanBuildpack string
-	offlineBuildpack   string
-	root               string
+	buildpack string
+	root      string
 
 	buildpackInfo struct {
 		Buildpack struct {


### PR DESCRIPTION
## Summary

The integration tests were failing because of buildpack version conflicts in the builder. We can use the buildpackless builder which has no buildpacks in it. This should not change the behavior as we are currently pulling in a complete list of buildpacks which are required to run the integration test.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
