### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/apache-tomee"
   id = "paketo-buildpacks/apache-tomee"
   keywords = ["java", "tomee", "war"]
-  name = "Paketo Apache Tomee Buildpack"
+  name = "Paketo Buildpack for Apache Tomee"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/vnd.syft+json"]
   version = "{{.version}}"
 


### PR DESCRIPTION
Renames 'Paketo Apache Tomee Buildpack' to 'Paketo Buildpack for Apache Tomee'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
