### PR TITLE
Fix missing `tomee.xml`

### DIFF
--- a/resources/tomee.xml
+++ b/resources/tomee.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<tomee>
+  <!-- see https://tomee.apache.org/latest/docs/admin/configuration/containers.html -->
+
+  <!-- activate next line to be able to deploy applications in apps -->
+  <!-- <Deployments dir="apps" /> -->
+</tomee>


### PR DESCRIPTION
## Summary

The missing `tomee.xml` currently leads to issues due to the run user not being able to modify any content in `/catalina-base`. The root-cause is similar to https://github.com/paketo-buildpacks/apache-tomcat/pull/248.

This leads to issues related to `openEJB`:

```
26-Oct-2022 13:07:06.514 INFO [main] org.apache.openejb.config.ConfigUtils.searchForConfiguration Cannot find the configuration file [conf/openejb.xml].  Creating one at /layers/paketo-buildpacks_apache-tomee/catalina-base/conf/openejb.xml
java.io.FileNotFoundException: /layers/paketo-buildpacks_apache-tomee/catalina-base/conf/openejb.xml (Permission denied)
	at java.io.FileOutputStream.open0(Native Method)
	at java.io.FileOutputStream.open(FileOutputStream.java:270)
	at java.io.FileOutputStream.<init>(FileOutputStream.java:213)
	at java.io.FileOutputStream.<init>(FileOutputStream.java:162)
	at org.apache.openejb.loader.IO.write(IO.java:357)
	at org.apache.openejb.loader.IO.copy(IO.java:282)
	at org.apache.openejb.config.ConfigUtils.createConfig(ConfigUtils.java:157)
	at org.apache.openejb.config.ConfigUtils.searchForConfiguration(ConfigUtils.java:132)
	at org.apache.openejb.config.ConfigurationFactory.init(ConfigurationFactory.java:433)
	at org.apache.openejb.assembler.classic.Assembler.init(Assembler.java:427)
	at org.apache.openejb.OpenEJB$Instance.<init>(OpenEJB.java:139)
	at org.apache.openejb.OpenEJB.init(OpenEJB.java:307)
	at org.apache.tomee.catalina.TomcatLoader.initialize(TomcatLoader.java:247)
	at org.apache.tomee.catalina.ServerListener.lifecycleEvent(ServerListener.java:168)
	at org.apache.catalina.util.LifecycleBase.fireLifecycleEvent(LifecycleBase.java:123)
	at org.apache.catalina.util.LifecycleBase.setStateInternal(LifecycleBase.java:423)
	at org.apache.catalina.util.LifecycleBase.init(LifecycleBase.java:137)
	at org.apache.catalina.startup.Catalina.load(Catalina.java:639)
	at org.apache.catalina.startup.Catalina.load(Catalina.java:662)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.catalina.startup.Bootstrap.load(Bootstrap.java:302)
	at org.apache.catalina.startup.Bootstrap.main(Bootstrap.java:472)
```

TomEE ships this (basically empty) file by default as well.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
