### PR TITLE
Make `tomee` run with a read-only root file system

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -28,7 +28,7 @@ api = "0.7"
     uri = "https://github.com/paketo-buildpacks/apache-tomee/blob/main/LICENSE"
 
 [metadata]
-  include-files = ["LICENSE", "NOTICE", "README.md", "bin/build", "bin/detect", "bin/helper", "bin/main", "buildpack.toml", "resources/context.xml", "resources/logging.properties", "resources/server.xml", "resources/web.xml"]
+  include-files = ["LICENSE", "NOTICE", "README.md", "bin/build", "bin/detect", "bin/helper", "bin/main", "buildpack.toml", "resources/context.xml", "resources/logging.properties", "resources/server.xml", "resources/web.xml", "resources/tomee.xml", "resources/openejb.xml"]
   pre-package = "scripts/build.sh"
 
   [[metadata.configurations]]

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -37,9 +37,12 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 			source string
 		)
 
+		const eventuallyTimeout = time.Second * 30
+
 		it.Before(func() {
 			var err error
 			name, err = occam.RandomName()
+
 			Expect(err).NotTo(HaveOccurred())
 
 			source, err = occam.Source(filepath.Join("testdata"))
@@ -88,10 +91,12 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 				WithEnv(map[string]string{"PORT": "8080"}).
 				WithPublish("8080").
 				WithPublishAll().
+				WithReadOnly().
+				WithMounts("type=bind,source=/tmp,target=/tmp").
 				Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(container, time.Second*30).Should(Serve(ContainSubstring("{\"application_status\":\"UP\"}")).OnPort(8080))
+			Eventually(container, eventuallyTimeout).Should(Serve(ContainSubstring("{\"application_status\":\"UP\"}")).OnPort(8080))
 		})
 
 		it("builds on tiny", func() {
@@ -128,10 +133,12 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 				}).
 				WithPublish("8080").
 				WithPublishAll().
+				WithReadOnly().
+				WithMounts("type=bind,source=/tmp,target=/tmp").
 				Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(container, time.Second*30).Should(Serve(ContainSubstring("{\"application_status\":\"UP\"}")).OnPort(8080))
+			Eventually(container, eventuallyTimeout).Should(Serve(ContainSubstring("{\"application_status\":\"UP\"}")).OnPort(8080))
 		})
 	})
 }

--- a/tomee/base.go
+++ b/tomee/base.go
@@ -179,6 +179,7 @@ func (b Base) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 		}
 
 		layer.LaunchEnvironment.Default("CATALINA_BASE", layer.Path)
+		layer.LaunchEnvironment.Default("CATALINA_TMPDIR", "/tmp")
 
 		if err := b.writeDependencySBOM(layer, syftArtifacts); err != nil {
 			return libcnb.Layer{}, err
@@ -263,6 +264,32 @@ func (b Base) ContributeConfiguration(layer libcnb.Layer) error {
 	defer in.Close()
 
 	file = filepath.Join(layer.Path, "conf", "web.xml")
+	if err := sherpa.CopyFile(in, file); err != nil {
+		return fmt.Errorf("unable to copy %s to %s\n%w", in.Name(), file, err)
+	}
+
+	b.Logger.Bodyf("Copying tomee.xml to %s/conf", layer.Path)
+	file = filepath.Join(b.BuildpackPath, "resources", "tomee.xml")
+	in, err = os.Open(file)
+	if err != nil {
+		return fmt.Errorf("unable to open %s\n%w", file, err)
+	}
+	defer in.Close()
+
+	file = filepath.Join(layer.Path, "conf", "tomee.xml")
+	if err := sherpa.CopyFile(in, file); err != nil {
+		return fmt.Errorf("unable to copy %s to %s\n%w", in.Name(), file, err)
+	}
+
+	b.Logger.Bodyf("Copying openejb.xml to %s/conf", layer.Path)
+	file = filepath.Join(b.BuildpackPath, "resources", "openejb.xml")
+	in, err = os.Open(file)
+	if err != nil {
+		return fmt.Errorf("unable to open %s\n%w", file, err)
+	}
+	defer in.Close()
+
+	file = filepath.Join(layer.Path, "conf", "openejb.xml")
 	if err := sherpa.CopyFile(in, file); err != nil {
 		return fmt.Errorf("unable to copy %s to %s\n%w", in.Name(), file, err)
 	}

--- a/tomee/base_test.go
+++ b/tomee/base_test.go
@@ -65,6 +65,10 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 			To(Succeed())
 		Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "web.xml"), []byte{}, 0644)).
 			To(Succeed())
+		Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "tomee.xml"), []byte{}, 0644)).
+			To(Succeed())
+		Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "openejb.xml"), []byte{}, 0644)).
+			To(Succeed())
 
 		accessLoggingDep := libpak.BuildpackDependency{
 			ID:     "tomcat-access-logging-support",
@@ -114,6 +118,8 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 		Expect(filepath.Join(layer.Path, "conf", "logging.properties")).To(BeARegularFile())
 		Expect(filepath.Join(layer.Path, "conf", "server.xml")).To(BeARegularFile())
 		Expect(filepath.Join(layer.Path, "conf", "web.xml")).To(BeARegularFile())
+		Expect(filepath.Join(layer.Path, "conf", "tomee.xml")).To(BeARegularFile())
+		Expect(filepath.Join(layer.Path, "conf", "openejb.xml")).To(BeARegularFile())
 		Expect(filepath.Join(layer.Path, "lib", "stub-tomcat-access-logging-support.jar")).To(BeARegularFile())
 		Expect(filepath.Join(layer.Path, "lib", "stub-tomcat-lifecycle-support.jar")).To(BeARegularFile())
 		Expect(filepath.Join(layer.Path, "bin", "stub-tomcat-logging-support.jar")).To(BeARegularFile())
@@ -141,6 +147,10 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 		Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "server.xml"), []byte{}, 0644)).
 			To(Succeed())
 		Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "web.xml"), []byte{}, 0644)).
+			To(Succeed())
+		Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "tomee.xml"), []byte{}, 0644)).
+			To(Succeed())
+		Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "openejb.xml"), []byte{}, 0644)).
 			To(Succeed())
 
 		externalConfigurationDep := libpak.BuildpackDependency{
@@ -203,6 +213,10 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 			Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "server.xml"), []byte{}, 0644)).
 				To(Succeed())
 			Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "web.xml"), []byte{}, 0644)).
+				To(Succeed())
+			Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "tomee.xml"), []byte{}, 0644)).
+				To(Succeed())
+			Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "openejb.xml"), []byte{}, 0644)).
 				To(Succeed())
 
 			externalConfigurationDep := libpak.BuildpackDependency{

--- a/tomee/build.go
+++ b/tomee/build.go
@@ -212,7 +212,6 @@ func (b Build) tinyStartCommand(homePath, basePath string, loggingDep libpak.Bui
 	arguments = append(arguments,
 		fmt.Sprintf("-Dcatalina.home=%s", homePath),
 		fmt.Sprintf("-Dcatalina.base=%s", basePath),
-		fmt.Sprintf("-Djava.io.tmpdir=%s", filepath.Join(basePath, "/temp")),
 		"org.apache.catalina.startup.Bootstrap", "start",
 	)
 

--- a/tomee/build_test.go
+++ b/tomee/build_test.go
@@ -238,7 +238,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					"catalina-base/bin/tomcat-logging-support-1.1.1.RELEASE.jar:tomee-microprofile/bin/bootstrap.jar:tomee-microprofile/bin/tomcat-juli.jar",
 					"-Dcatalina.home=tomee-microprofile",
 					"-Dcatalina.base=catalina-base",
-					"-Djava.io.tmpdir=catalina-base/temp",
 					"org.apache.catalina.startup.Bootstrap",
 					"start",
 				},


### PR DESCRIPTION
fixes #104 

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

The buildpack should start `tomee` to be able to run with a readonly root filesystem..

## Summary
<!-- A short explanation of the proposed change -->

* Adding empty `openejb.xml` so it does not have to be created
* For tiny stack, do not set `java.io.tmpdir` and rely on the default `/tmp`
* For other stacks it will set `CATALINA_TMPDIR` to `/tmp`

## Use Cases
<!-- An explanation of the use cases your change enables -->

With that change, it is possible to mount a read-only file system as long as you have a writeable `/tmp`.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
