### PR TITLE
prevent logging to files

### DIFF
--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -139,6 +139,9 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(container, eventuallyTimeout).Should(Serve(ContainSubstring("{\"application_status\":\"UP\"}")).OnPort(8080))
+			logs, err = docker.Container.Logs.Execute(container.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(logs.String()).To(ContainSubstring("[ACCESS]"))
 		})
 	})
 }

--- a/resources/logging.properties
+++ b/resources/logging.properties
@@ -13,43 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-handlers = 1catalina.org.apache.juli.AsyncFileHandler, 2localhost.org.apache.juli.AsyncFileHandler, 3manager.org.apache.juli.AsyncFileHandler, 4host-manager.org.apache.juli.AsyncFileHandler, org.apache.tomee.jul.formatter.AsyncConsoleHandler
+handlers = org.apache.tomee.jul.formatter.AsyncConsoleHandler
 
-.handlers = 1catalina.org.apache.juli.AsyncFileHandler, org.apache.tomee.jul.formatter.AsyncConsoleHandler
+.handlers = org.apache.tomee.jul.formatter.AsyncConsoleHandler
 
 ############################################################
 # Handler specific properties.
 # Describes specific configuration info for Handlers.
 ############################################################
 
-1catalina.org.apache.juli.AsyncFileHandler.level = FINE
-1catalina.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
-1catalina.org.apache.juli.AsyncFileHandler.prefix = catalina.
-1catalina.org.apache.juli.AsyncFileHandler.maxDays = 90
-1catalina.org.apache.juli.AsyncFileHandler.encoding = UTF-8
-
-2localhost.org.apache.juli.AsyncFileHandler.level = FINE
-2localhost.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
-2localhost.org.apache.juli.AsyncFileHandler.prefix = localhost.
-2localhost.org.apache.juli.AsyncFileHandler.maxDays = 90
-2localhost.org.apache.juli.AsyncFileHandler.encoding = UTF-8
-
-3manager.org.apache.juli.AsyncFileHandler.level = FINE
-3manager.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
-3manager.org.apache.juli.AsyncFileHandler.prefix = manager.
-3manager.org.apache.juli.AsyncFileHandler.maxDays = 90
-3manager.org.apache.juli.AsyncFileHandler.encoding = UTF-8
-
-4host-manager.org.apache.juli.AsyncFileHandler.level = FINE
-4host-manager.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
-4host-manager.org.apache.juli.AsyncFileHandler.prefix = host-manager.
-4host-manager.org.apache.juli.AsyncFileHandler.maxDays = 90
-4host-manager.org.apache.juli.AsyncFileHandler.encoding = UTF-8
-
 org.apache.tomee.jul.formatter.AsyncConsoleHandler.level = FINE
 org.apache.tomee.jul.formatter.AsyncConsoleHandler.formatter = org.apache.juli.OneLineFormatter
 org.apache.tomee.jul.formatter.AsyncConsoleHandler.encoding = UTF-8
-
 
 ############################################################
 # Facility specific properties.
@@ -57,13 +32,8 @@ org.apache.tomee.jul.formatter.AsyncConsoleHandler.encoding = UTF-8
 ############################################################
 
 org.apache.catalina.core.ContainerBase.[Catalina].[localhost].level = INFO
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].handlers = 2localhost.org.apache.juli.AsyncFileHandler
-
 org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].level = INFO
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].handlers = 3manager.org.apache.juli.AsyncFileHandler
-
 org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].level = INFO
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].handlers = 4host-manager.org.apache.juli.AsyncFileHandler
 
 # For example, set the org.apache.catalina.util.LifecycleBase logger to log
 # each component that extends LifecycleBase changing state:

--- a/resources/server.xml
+++ b/resources/server.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <!--
   ~ Copyright 2018-2022 the original author or authors.
   ~
@@ -14,31 +14,36 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<Server port="-1">
+<Server port='-1'>
     <!-- TomEE plugin for Tomcat -->
-    <Listener className="org.apache.tomee.catalina.ServerListener"/>
-    <Listener className="org.apache.catalina.startup.VersionLoggerListener"/>
+    <Listener className='org.apache.tomee.catalina.ServerListener'/>
+    <Listener className='org.apache.catalina.startup.VersionLoggerListener'/>
     <!-- Security listener. Documentation at /docs/config/listeners.html
-    <Listener className="org.apache.catalina.security.SecurityListener" />
+    <Listener className='org.apache.catalina.security.SecurityListener' />
     -->
     <!-- APR library loader. Documentation at /docs/apr.html -->
-    <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on"/>
+    <Listener className='org.apache.catalina.core.AprLifecycleListener' SSLEngine='on'/>
     <!-- Prevent memory leaks due to use of particular java/javax APIs-->
-    <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener"/>
-    <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener"/>
-    <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener"/>
+    <Listener className='org.apache.catalina.core.JreMemoryLeakPreventionListener'/>
+    <Listener className='org.apache.catalina.mbeans.GlobalResourcesLifecycleListener'/>
+    <Listener className='org.apache.catalina.core.ThreadLocalLeakPreventionListener'/>
 
-    <Service name="Catalina">
-        <Connector port="8080" protocol="HTTP/1.1" bindOnInit="false" connectionTimeout="20000" xpoweredBy="false" />
-        <Engine name="Catalina" defaultHost="localhost">
-            <Valve className="org.apache.catalina.valves.RemoteIpValve" protocolHeader="x-forwarded-proto" />
-            <Valve className="org.cloudfoundry.tomcat.logging.access.CloudFoundryAccessLoggingValve"
-                   pattern="[ACCESS] %{org.apache.catalina.AccessLog.RemoteAddr}r %l %t %D %F %B %S vcap_request_id:%{X-Vcap-Request-Id}i"
-                   enabled="${access.logging.enabled}" />
-            <Host name="localhost" failCtxIfServletStartFails="true">
-                <Listener className="org.cloudfoundry.tomcat.lifecycle.ApplicationStartupFailureDetectingLifecycleListener" />
-                <Valve className="org.apache.catalina.valves.ErrorReportValve" showReport="false" showServerInfo="false" />
+    <Service name='Catalina'>
+        <Connector port='8080' protocol='HTTP/1.1' bindOnInit='false' connectionTimeout='20000' xpoweredBy='false' />
+        <Engine defaultHost='localhost' name='Catalina'>
+            <Valve className='org.apache.catalina.valves.RemoteIpValve' protocolHeader='x-forwarded-proto' />
+            <Valve className='org.cloudfoundry.tomcat.logging.access.CloudFoundryAccessLoggingValve'
+                   pattern='[ACCESS] %{org.apache.catalina.AccessLog.RemoteAddr}r %l %t %D %F %B %S vcap_request_id:%{X-Vcap-Request-Id}i'
+                   directory='${java.io.tmpdir}/logs'
+                   enabled='${access.logging.enabled}' />
+            <Host name='localhost'
+                  failCtxIfServletStartFails='true'
+                  createDirs='false'
+                  workDir='${java.io.tmpdir}/workDir'>
+                <Listener className='org.cloudfoundry.tomcat.lifecycle.ApplicationStartupFailureDetectingLifecycleListener' />
+                <Valve className='org.apache.catalina.valves.ErrorReportValve' showReport='false' showServerInfo='false' />
             </Host>
         </Engine>
     </Service>
+
 </Server>


### PR DESCRIPTION
## Summary

- minimize diff between `resources/server.xml` and [the same file in the `apache-tomcat` buildpack](https://github.com/paketo-buildpacks/apache-tomcat/blob/1e93d9d5011d95ac5d6b32378f6b73765e0ae906/resources/server.xml#L19).
  includes stylistic changes (e.g. changing from `"` to `'` for quoting), but also some read-only fs related changes like switching the logging directory to the tmp dir (`directory='${java.io.tmpdir}/logs'`)
- Remove any non console loggers from `resources/logging.properties`
- Improve integration test: actually verify access logs are written.

## Use Cases
<!-- An explanation of the use cases your change enables -->

Fixes https://github.com/paketo-buildpacks/apache-tomee/issues/107 Note: this issue also mentions the lifecycle helper, which IMHO is unrelated to the issue and should be moved into a separate issue.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
