### PR TITLE
Update `pipeline-descriptor.yml`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @paketo-buildpacks/java-buildpacks
+* @paketo-buildpacks/java-maintainers

--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -1,20 +1,23 @@
 github:
   username: ${{ secrets.JAVA_GITHUB_USERNAME }}
-  token:    ${{ secrets.JAVA_GITHUB_TOKEN }}
+  token:    ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
 
 codeowners:
 - path:  "*"
-  owner: "@paketo-buildpacks/java-buildpacks"
+  owner: "@paketo-buildpacks/java-maintainers"
 
 package:
-  repository:     gcr.io/paketo-buildpacks/apache-tomee
+  repositories:   ["docker.io/paketobuildpacks/apache-tomee","gcr.io/paketo-buildpacks/apache-tomee"]
   register:       true
-  registry_token: ${{ secrets.JAVA_GITHUB_TOKEN }}
+  registry_token: ${ secrets.PAKETO_BOT_GITHUB_TOKEN }
 
 docker_credentials:
 - registry: gcr.io
   username: _json_key
-  password: ${{ secrets.JAVA_GCLOUD_SERVICE_ACCOUNT_KEY }}
+  password: ${{ secrets.GCR_PUSH_BOT_JSON_KEY }}
+- registry: docker.io
+  username: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }}
+  password: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD }}
 
 dependencies:
 - name:            Tomee 7 Microprofile

--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -9,7 +9,7 @@ codeowners:
 package:
   repositories:   ["docker.io/paketobuildpacks/apache-tomee","gcr.io/paketo-buildpacks/apache-tomee"]
   register:       true
-  registry_token: ${ secrets.PAKETO_BOT_GITHUB_TOKEN }
+  registry_token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
 
 docker_credentials:
 - registry: gcr.io

--- a/.github/workflows/pb-create-package.yml
+++ b/.github/workflows/pb-create-package.yml
@@ -13,9 +13,16 @@ jobs:
               if: ${{ (github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork) && (github.actor != 'dependabot[bot]') }}
               uses: docker/login-action@v2
               with:
-                password: ${{ secrets.JAVA_GCLOUD_SERVICE_ACCOUNT_KEY }}
+                password: ${{ secrets.GCR_PUSH_BOT_JSON_KEY }}
                 registry: gcr.io
                 username: _json_key
+            - name: Docker login docker.io
+              if: ${{ (github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork) && (github.actor != 'dependabot[bot]') }}
+              uses: docker/login-action@v2
+              with:
+                password: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD }}
+                registry: docker.io
+                username: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }}
             - uses: actions/setup-go@v3
               with:
                 go-version: "1.18"
@@ -102,15 +109,15 @@ jobs:
                   MAJOR_VERSION="$(echo "${VERSION}" | awk -F '.' '{print $1 }')"
                   MINOR_VERSION="$(echo "${VERSION}" | awk -F '.' '{print $1 "." $2 }')"
 
-                  echo "::set-output name=version-major::${MAJOR_VERSION}"
-                  echo "::set-output name=version-minor::${MINOR_VERSION}"
+                  echo "version-major=${MAJOR_VERSION}" >> "$GITHUB_OUTPUT"
+                  echo "version-minor=${MINOR_VERSION}" >> "$GITHUB_OUTPUT"
                 elif [[ ${GITHUB_REF} =~ refs/heads/(.+) ]]; then
                   VERSION=${BASH_REMATCH[1]}
                 else
                   VERSION=$(git rev-parse --short HEAD)
                 fi
 
-                echo "::set-output name=version::${VERSION}"
+                echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
                 echo "Selected ${VERSION} from
                   * ref: ${GITHUB_REF}
                   * sha: ${GITHUB_SHA}
@@ -166,7 +173,7 @@ jobs:
                     crane tag "${PACKAGE}:${VERSION}" "${VERSION_MAJOR}"
                   fi
                   crane tag "${PACKAGE}:${VERSION}" latest
-                  echo "::set-output name=digest::$(crane digest "${PACKAGE}:${VERSION}")"
+                  echo "digest=$(crane digest "${PACKAGE}:${VERSION}")" >> "$GITHUB_OUTPUT"
 
                   # copy to other repositories specified
                   for P in "${PACKAGE_LIST[@]}"
@@ -188,7 +195,7 @@ jobs:
                     --format "${FORMAT}"
                 fi
               env:
-                PACKAGES: gcr.io/paketo-buildpacks/apache-tomee
+                PACKAGES: docker.io/paketobuildpacks/apache-tomee gcr.io/paketo-buildpacks/apache-tomee
                 PUBLISH: "true"
                 VERSION: ${{ steps.version.outputs.version }}
                 VERSION_MAJOR: ${{ steps.version.outputs.version-major }}
@@ -214,11 +221,11 @@ jobs:
                   --field "body=${RELEASE_BODY//<!-- DIGEST PLACEHOLDER -->/\`${DIGEST}\`}"
               env:
                 DIGEST: ${{ steps.package.outputs.digest }}
-                GITHUB_TOKEN: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
             - if: ${{ true }}
               uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:4.0.1
               with:
-                address: gcr.io/paketo-buildpacks/apache-tomee@${{ steps.package.outputs.digest }}
+                address: docker.io/paketobuildpacks/apache-tomee@${{ steps.package.outputs.digest }}
                 id: paketo-buildpacks/apache-tomee
-                token: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                token: ${ secrets.PAKETO_BOT_GITHUB_TOKEN }
                 version: ${{ steps.version.outputs.version }}

--- a/.github/workflows/pb-minimal-labels.yml
+++ b/.github/workflows/pb-minimal-labels.yml
@@ -12,7 +12,7 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - uses: mheap/github-action-required-labels@v2
+            - uses: mheap/github-action-required-labels@v3
               with:
                 count: 1
                 labels: semver:major, semver:minor, semver:patch
@@ -22,7 +22,7 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - uses: mheap/github-action-required-labels@v2
+            - uses: mheap/github-action-required-labels@v3
               with:
                 count: 1
                 labels: type:bug, type:dependency-upgrade, type:documentation, type:enhancement, type:question, type:task

--- a/.github/workflows/pb-synchronize-labels.yml
+++ b/.github/workflows/pb-synchronize-labels.yml
@@ -14,4 +14,4 @@ jobs:
             - uses: actions/checkout@v3
             - uses: micnncim/action-label-syncer@v1
               env:
-                GITHUB_TOKEN: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-tests.yml
+++ b/.github/workflows/pb-tests.yml
@@ -76,15 +76,15 @@ jobs:
                   MAJOR_VERSION="$(echo "${VERSION}" | awk -F '.' '{print $1 }')"
                   MINOR_VERSION="$(echo "${VERSION}" | awk -F '.' '{print $1 "." $2 }')"
 
-                  echo "::set-output name=version-major::${MAJOR_VERSION}"
-                  echo "::set-output name=version-minor::${MINOR_VERSION}"
+                  echo "version-major=${MAJOR_VERSION}" >> "$GITHUB_OUTPUT"
+                  echo "version-minor=${MINOR_VERSION}" >> "$GITHUB_OUTPUT"
                 elif [[ ${GITHUB_REF} =~ refs/heads/(.+) ]]; then
                   VERSION=${BASH_REMATCH[1]}
                 else
                   VERSION=$(git rev-parse --short HEAD)
                 fi
 
-                echo "::set-output name=version::${VERSION}"
+                echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
                 echo "Selected ${VERSION} from
                   * ref: ${GITHUB_REF}
                   * sha: ${GITHUB_SHA}
@@ -138,7 +138,7 @@ jobs:
                     crane tag "${PACKAGE}:${VERSION}" "${VERSION_MAJOR}"
                   fi
                   crane tag "${PACKAGE}:${VERSION}" latest
-                  echo "::set-output name=digest::$(crane digest "${PACKAGE}:${VERSION}")"
+                  echo "digest=$(crane digest "${PACKAGE}:${VERSION}")" >> "$GITHUB_OUTPUT"
 
                   # copy to other repositories specified
                   for P in "${PACKAGE_LIST[@]}"

--- a/.github/workflows/pb-update-draft-release.yml
+++ b/.github/workflows/pb-update-draft-release.yml
@@ -12,12 +12,12 @@ jobs:
             - id: release-drafter
               uses: release-drafter/release-drafter@v5
               env:
-                GITHUB_TOKEN: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
             - uses: actions/checkout@v3
             - name: Update draft release with buildpack information
               uses: docker://ghcr.io/paketo-buildpacks/actions/draft-release:main
               with:
-                github_token: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                github_token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
                 release_body: ${{ steps.release-drafter.outputs.body }}
                 release_id: ${{ steps.release-drafter.outputs.id }}
                 release_name: ${{ steps.release-drafter.outputs.name }}

--- a/.github/workflows/pb-update-go.yml
+++ b/.github/workflows/pb-update-go.yml
@@ -1,7 +1,7 @@
 name: Update Go
 "on":
     schedule:
-        - cron: 0 2 * * 1
+        - cron: 14 2 * * 1
     workflow_dispatch: {}
 jobs:
     update:
@@ -45,9 +45,9 @@ jobs:
                     COMMIT_SEMVER="semver:minor"
                 fi
 
-                echo "::set-output name=commit-title::${COMMIT_TITLE}"
-                echo "::set-output name=commit-body::${COMMIT_BODY}"
-                echo "::set-output name=commit-semver::${COMMIT_SEMVER}"
+                echo "commit-title=${COMMIT_TITLE}" >> "$GITHUB_OUTPUT"
+                echo "commit-body=${COMMIT_BODY}" >> "$GITHUB_OUTPUT"
+                echo "commit-semver=${COMMIT_SEMVER}" >> "$GITHUB_OUTPUT"
               env:
                 GO_VERSION: "1.18"
             - uses: peter-evans/create-pull-request@v4
@@ -69,4 +69,4 @@ jobs:
                 labels: ${{ steps.update-go.outputs.commit-semver }}, type:task
                 signoff: true
                 title: ${{ steps.update-go.outputs.commit-title }}
-                token: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-pipeline.yml
+++ b/.github/workflows/pb-update-pipeline.yml
@@ -57,12 +57,14 @@ jobs:
                 git add .github/
                 git checkout -- .
 
-                echo "::set-output name=old-version::${OLD_VERSION}"
-                echo "::set-output name=new-version::${NEW_VERSION}"
-                echo "::set-output name=release-notes::${RELEASE_NOTES//$'\n'/%0A}"
+                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
+                echo "new-version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+
+                DELIMITER=$(openssl rand -hex 16) # roughly the same entropy as uuid v4 used in https://github.com/actions/toolkit/blob/b36e70495fbee083eb20f600eafa9091d832577d/packages/core/src/file-command.ts#L28
+                printf "release-notes<<%s\n%s\n%s\n" "${DELIMITER}" "${RELEASE_NOTES}" "${DELIMITER}" >> "${GITHUB_OUTPUT}" # see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
               env:
                 DESCRIPTOR: .github/pipeline-descriptor.yml
-                GITHUB_TOKEN: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
             - uses: peter-evans/create-pull-request@v4
               with:
                 author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
@@ -82,4 +84,4 @@ jobs:
                 labels: semver:patch, type:task
                 signoff: true
                 title: Bump pipeline from ${{ steps.pipeline.outputs.old-version }} to ${{ steps.pipeline.outputs.new-version }}
-                token: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-tomcat-access-logging-support.yml
+++ b/.github/workflows/pb-update-tomcat-access-logging-support.yml
@@ -50,7 +50,7 @@ jobs:
                 version_regex: ^[\d]+\.[\d]+\.[\d]+\.RELEASE$
             - name: Update Buildpack Dependency
               id: buildpack
-              run: |-
+              run: |
                 #!/usr/bin/env bash
 
                 set -euo pipefail
@@ -84,9 +84,9 @@ jobs:
                   LABEL="semver:patch"
                 fi
 
-                echo "::set-output name=old-version::${OLD_VERSION}"
-                echo "::set-output name=new-version::${VERSION}"
-                echo "::set-output name=version-label::${LABEL}"
+                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
+                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
+                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: ""
@@ -110,4 +110,4 @@ jobs:
                 labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
                 signoff: true
                 title: Bump tomcat-access-logging-support from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
-                token: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-tomcat-lifecycle-support.yml
+++ b/.github/workflows/pb-update-tomcat-lifecycle-support.yml
@@ -50,7 +50,7 @@ jobs:
                 version_regex: ^[\d]+\.[\d]+\.[\d]+\.RELEASE$
             - name: Update Buildpack Dependency
               id: buildpack
-              run: |-
+              run: |
                 #!/usr/bin/env bash
 
                 set -euo pipefail
@@ -84,9 +84,9 @@ jobs:
                   LABEL="semver:patch"
                 fi
 
-                echo "::set-output name=old-version::${OLD_VERSION}"
-                echo "::set-output name=new-version::${VERSION}"
-                echo "::set-output name=version-label::${LABEL}"
+                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
+                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
+                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: ""
@@ -110,4 +110,4 @@ jobs:
                 labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
                 signoff: true
                 title: Bump tomcat-lifecycle-support from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
-                token: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-tomcat-logging-support.yml
+++ b/.github/workflows/pb-update-tomcat-logging-support.yml
@@ -50,7 +50,7 @@ jobs:
                 version_regex: ^[\d]+\.[\d]+\.[\d]+\.RELEASE$
             - name: Update Buildpack Dependency
               id: buildpack
-              run: |-
+              run: |
                 #!/usr/bin/env bash
 
                 set -euo pipefail
@@ -84,9 +84,9 @@ jobs:
                   LABEL="semver:patch"
                 fi
 
-                echo "::set-output name=old-version::${OLD_VERSION}"
-                echo "::set-output name=new-version::${VERSION}"
-                echo "::set-output name=version-label::${LABEL}"
+                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
+                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
+                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: ""
@@ -110,4 +110,4 @@ jobs:
                 labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
                 signoff: true
                 title: Bump tomcat-logging-support from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
-                token: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-tomee-7-microprofile.yml
+++ b/.github/workflows/pb-update-tomee-7-microprofile.yml
@@ -49,7 +49,7 @@ jobs:
                 uri: https://archive.apache.org/dist/tomee
             - name: Update Buildpack Dependency
               id: buildpack
-              run: |-
+              run: |
                 #!/usr/bin/env bash
 
                 set -euo pipefail
@@ -83,9 +83,9 @@ jobs:
                   LABEL="semver:patch"
                 fi
 
-                echo "::set-output name=old-version::${OLD_VERSION}"
-                echo "::set-output name=new-version::${VERSION}"
-                echo "::set-output name=version-label::${LABEL}"
+                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
+                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
+                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: ""
@@ -109,4 +109,4 @@ jobs:
                 labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
                 signoff: true
                 title: Bump Tomee 7 Microprofile from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
-                token: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-tomee-7-plume.yml
+++ b/.github/workflows/pb-update-tomee-7-plume.yml
@@ -49,7 +49,7 @@ jobs:
                 uri: https://archive.apache.org/dist/tomee
             - name: Update Buildpack Dependency
               id: buildpack
-              run: |-
+              run: |
                 #!/usr/bin/env bash
 
                 set -euo pipefail
@@ -83,9 +83,9 @@ jobs:
                   LABEL="semver:patch"
                 fi
 
-                echo "::set-output name=old-version::${OLD_VERSION}"
-                echo "::set-output name=new-version::${VERSION}"
-                echo "::set-output name=version-label::${LABEL}"
+                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
+                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
+                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: ""
@@ -109,4 +109,4 @@ jobs:
                 labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
                 signoff: true
                 title: Bump Tomee 7 Plume from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
-                token: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-tomee-7-plus.yml
+++ b/.github/workflows/pb-update-tomee-7-plus.yml
@@ -49,7 +49,7 @@ jobs:
                 uri: https://archive.apache.org/dist/tomee
             - name: Update Buildpack Dependency
               id: buildpack
-              run: |-
+              run: |
                 #!/usr/bin/env bash
 
                 set -euo pipefail
@@ -83,9 +83,9 @@ jobs:
                   LABEL="semver:patch"
                 fi
 
-                echo "::set-output name=old-version::${OLD_VERSION}"
-                echo "::set-output name=new-version::${VERSION}"
-                echo "::set-output name=version-label::${LABEL}"
+                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
+                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
+                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: ""
@@ -109,4 +109,4 @@ jobs:
                 labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
                 signoff: true
                 title: Bump Tomee 7 Plus from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
-                token: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-tomee-7-webprofile.yml
+++ b/.github/workflows/pb-update-tomee-7-webprofile.yml
@@ -49,7 +49,7 @@ jobs:
                 uri: https://archive.apache.org/dist/tomee
             - name: Update Buildpack Dependency
               id: buildpack
-              run: |-
+              run: |
                 #!/usr/bin/env bash
 
                 set -euo pipefail
@@ -83,9 +83,9 @@ jobs:
                   LABEL="semver:patch"
                 fi
 
-                echo "::set-output name=old-version::${OLD_VERSION}"
-                echo "::set-output name=new-version::${VERSION}"
-                echo "::set-output name=version-label::${LABEL}"
+                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
+                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
+                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: ""
@@ -109,4 +109,4 @@ jobs:
                 labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
                 signoff: true
                 title: Bump Tomee 7 Webprofile from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
-                token: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-tomee-8-microprofile.yml
+++ b/.github/workflows/pb-update-tomee-8-microprofile.yml
@@ -49,7 +49,7 @@ jobs:
                 uri: https://archive.apache.org/dist/tomee
             - name: Update Buildpack Dependency
               id: buildpack
-              run: |-
+              run: |
                 #!/usr/bin/env bash
 
                 set -euo pipefail
@@ -83,9 +83,9 @@ jobs:
                   LABEL="semver:patch"
                 fi
 
-                echo "::set-output name=old-version::${OLD_VERSION}"
-                echo "::set-output name=new-version::${VERSION}"
-                echo "::set-output name=version-label::${LABEL}"
+                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
+                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
+                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: ""
@@ -109,4 +109,4 @@ jobs:
                 labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
                 signoff: true
                 title: Bump Tomee 8 Microprofile from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
-                token: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-tomee-8-plume.yml
+++ b/.github/workflows/pb-update-tomee-8-plume.yml
@@ -49,7 +49,7 @@ jobs:
                 uri: https://archive.apache.org/dist/tomee
             - name: Update Buildpack Dependency
               id: buildpack
-              run: |-
+              run: |
                 #!/usr/bin/env bash
 
                 set -euo pipefail
@@ -83,9 +83,9 @@ jobs:
                   LABEL="semver:patch"
                 fi
 
-                echo "::set-output name=old-version::${OLD_VERSION}"
-                echo "::set-output name=new-version::${VERSION}"
-                echo "::set-output name=version-label::${LABEL}"
+                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
+                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
+                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: ""
@@ -109,4 +109,4 @@ jobs:
                 labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
                 signoff: true
                 title: Bump Tomee 8 Plume from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
-                token: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-tomee-8-plus.yml
+++ b/.github/workflows/pb-update-tomee-8-plus.yml
@@ -49,7 +49,7 @@ jobs:
                 uri: https://archive.apache.org/dist/tomee
             - name: Update Buildpack Dependency
               id: buildpack
-              run: |-
+              run: |
                 #!/usr/bin/env bash
 
                 set -euo pipefail
@@ -83,9 +83,9 @@ jobs:
                   LABEL="semver:patch"
                 fi
 
-                echo "::set-output name=old-version::${OLD_VERSION}"
-                echo "::set-output name=new-version::${VERSION}"
-                echo "::set-output name=version-label::${LABEL}"
+                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
+                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
+                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: ""
@@ -109,4 +109,4 @@ jobs:
                 labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
                 signoff: true
                 title: Bump Tomee 8 Plus from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
-                token: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-tomee-8-webprofile.yml
+++ b/.github/workflows/pb-update-tomee-8-webprofile.yml
@@ -49,7 +49,7 @@ jobs:
                 uri: https://archive.apache.org/dist/tomee
             - name: Update Buildpack Dependency
               id: buildpack
-              run: |-
+              run: |
                 #!/usr/bin/env bash
 
                 set -euo pipefail
@@ -83,9 +83,9 @@ jobs:
                   LABEL="semver:patch"
                 fi
 
-                echo "::set-output name=old-version::${OLD_VERSION}"
-                echo "::set-output name=new-version::${VERSION}"
-                echo "::set-output name=version-label::${LABEL}"
+                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
+                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
+                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: ""
@@ -109,4 +109,4 @@ jobs:
                 labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
                 signoff: true
                 title: Bump Tomee 8 Webprofile from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
-                token: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-tomee-9-microprofile.yml
+++ b/.github/workflows/pb-update-tomee-9-microprofile.yml
@@ -49,7 +49,7 @@ jobs:
                 uri: https://archive.apache.org/dist/tomee
             - name: Update Buildpack Dependency
               id: buildpack
-              run: |-
+              run: |
                 #!/usr/bin/env bash
 
                 set -euo pipefail
@@ -83,9 +83,9 @@ jobs:
                   LABEL="semver:patch"
                 fi
 
-                echo "::set-output name=old-version::${OLD_VERSION}"
-                echo "::set-output name=new-version::${VERSION}"
-                echo "::set-output name=version-label::${LABEL}"
+                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
+                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
+                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: ""
@@ -109,4 +109,4 @@ jobs:
                 labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
                 signoff: true
                 title: Bump Tomee 9 Microprofile from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
-                token: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-tomee-9-plume.yml
+++ b/.github/workflows/pb-update-tomee-9-plume.yml
@@ -49,7 +49,7 @@ jobs:
                 uri: https://archive.apache.org/dist/tomee
             - name: Update Buildpack Dependency
               id: buildpack
-              run: |-
+              run: |
                 #!/usr/bin/env bash
 
                 set -euo pipefail
@@ -83,9 +83,9 @@ jobs:
                   LABEL="semver:patch"
                 fi
 
-                echo "::set-output name=old-version::${OLD_VERSION}"
-                echo "::set-output name=new-version::${VERSION}"
-                echo "::set-output name=version-label::${LABEL}"
+                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
+                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
+                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: ""
@@ -109,4 +109,4 @@ jobs:
                 labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
                 signoff: true
                 title: Bump Tomee 9 Plume from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
-                token: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-tomee-9-plus.yml
+++ b/.github/workflows/pb-update-tomee-9-plus.yml
@@ -49,7 +49,7 @@ jobs:
                 uri: https://archive.apache.org/dist/tomee
             - name: Update Buildpack Dependency
               id: buildpack
-              run: |-
+              run: |
                 #!/usr/bin/env bash
 
                 set -euo pipefail
@@ -83,9 +83,9 @@ jobs:
                   LABEL="semver:patch"
                 fi
 
-                echo "::set-output name=old-version::${OLD_VERSION}"
-                echo "::set-output name=new-version::${VERSION}"
-                echo "::set-output name=version-label::${LABEL}"
+                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
+                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
+                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: ""
@@ -109,4 +109,4 @@ jobs:
                 labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
                 signoff: true
                 title: Bump Tomee 9 Plus from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
-                token: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-tomee-9-webprofile.yml
+++ b/.github/workflows/pb-update-tomee-9-webprofile.yml
@@ -49,7 +49,7 @@ jobs:
                 uri: https://archive.apache.org/dist/tomee
             - name: Update Buildpack Dependency
               id: buildpack
-              run: |-
+              run: |
                 #!/usr/bin/env bash
 
                 set -euo pipefail
@@ -83,9 +83,9 @@ jobs:
                   LABEL="semver:patch"
                 fi
 
-                echo "::set-output name=old-version::${OLD_VERSION}"
-                echo "::set-output name=new-version::${VERSION}"
-                echo "::set-output name=version-label::${LABEL}"
+                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
+                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
+                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: ""
@@ -109,4 +109,4 @@ jobs:
                 labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
                 signoff: true
                 title: Bump Tomee 9 Webprofile from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
-                token: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Update `pipeline-descriptor.yml` to use new tokens, codeowners, and to publish to DockerHub as well as GCR.io
