### PR TITLE
Adds CGO flag to build script for Go 1.20+

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,6 +2,7 @@
 
 set -euo pipefail
 
+export CGO_ENABLED=0
 GOOS="linux" go build -ldflags='-s -w' -o bin/helper github.com/paketo-buildpacks/apache-tomee/cmd/helper
 GOOS="linux" go build -ldflags='-s -w' -o bin/main github.com/paketo-buildpacks/apache-tomee/cmd/main
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
This PR sets the CGO_ENABLED to true in the build script. See paketo-buildpacks/pipeline-builder#1089 for more details.

## Use Cases
Fixes failing integration tests which build the buildpack on the fly.
Fixes #161 
## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
