### PR TITLE
uses dependency URI instead of cache artifact name for classpath

### DIFF
--- a/tomee/base.go
+++ b/tomee/base.go
@@ -200,9 +200,9 @@ func (b Base) ContributeAccessLogging(layer libcnb.Layer) error {
 
 	b.Logger.Bodyf("Copying to %s/lib", layer.Path)
 
-	file := filepath.Join(layer.Path, "lib", filepath.Base(artifact.Name()))
+	file := filepath.Join(layer.Path, "lib", filepath.Base(b.AccessLoggingDependency.URI))
 	if err := sherpa.CopyFile(artifact, file); err != nil {
-		return fmt.Errorf("unable to copy %s to %s\n%w", artifact.Name(), file, err)
+		return fmt.Errorf("unable to copy %s to %s\n%w", filepath.Base(b.AccessLoggingDependency.URI), file, err)
 	}
 
 	return nil
@@ -333,9 +333,9 @@ func (b Base) ContributeLifecycle(layer libcnb.Layer) error {
 
 	b.Logger.Bodyf("Copying to %s/lib", layer.Path)
 
-	file := filepath.Join(layer.Path, "lib", filepath.Base(artifact.Name()))
+	file := filepath.Join(layer.Path, "lib", filepath.Base(b.LifecycleDependency.URI))
 	if err := sherpa.CopyFile(artifact, file); err != nil {
-		return fmt.Errorf("unable to copy %s to %s\n%w", artifact.Name(), file, err)
+		return fmt.Errorf("unable to copy %s to %s\n%w", filepath.Base(b.LifecycleDependency.URI), file, err)
 	}
 
 	return nil
@@ -352,9 +352,9 @@ func (b Base) ContributeLogging(layer libcnb.Layer) error {
 
 	b.Logger.Bodyf("Copying to %s/bin", layer.Path)
 
-	file := filepath.Join(layer.Path, "bin", filepath.Base(artifact.Name()))
+	file := filepath.Join(layer.Path, "bin", filepath.Base(b.LoggingDependency.URI))
 	if err := sherpa.CopyFile(artifact, file); err != nil {
-		return fmt.Errorf("unable to copy %s to %s\n%w", artifact.Name(), file, err)
+		return fmt.Errorf("unable to copy %s to %s\n%w", filepath.Base(b.LoggingDependency.URI), file, err)
 	}
 
 	b.Logger.Bodyf("Writing %s/bin/setenv.sh", layer.Path)


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
The change in https://github.com/paketo-buildpacks/libpak/pull/273 introduced a bug where the artifact name was used as the classpath entry - this lead to the SHA value being added to the classpath rather than the library name. This PR uses the dependency URI base name instead which resolves to the actual library name.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
