### PR TITLE
Do not use effect.NewExecutor use CommandExecutor instead

### DIFF
--- a/tomee/build.go
+++ b/tomee/build.go
@@ -171,7 +171,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	)
 
 	if b.SBOMScanner == nil {
-		b.SBOMScanner = sbom.NewSyftCLISBOMScanner(context.Layers, effect.NewExecutor(), b.Logger)
+		b.SBOMScanner = sbom.NewSyftCLISBOMScanner(context.Layers, effect.CommandExecutor{}, b.Logger)
 	}
 	if err := b.SBOMScanner.ScanLaunch(context.Application.Path, libcnb.SyftJSON, libcnb.CycloneDXJSON); err != nil {
 		return libcnb.BuildResult{}, fmt.Errorf("unable to create Launch SBoM \n%w", err)

--- a/tomee/build_test.go
+++ b/tomee/build_test.go
@@ -50,6 +50,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		sbomScanner.On("ScanLaunch", ctx.Application.Path, libcnb.SyftJSON, libcnb.CycloneDXJSON).Return(nil)
 
 		Expect(os.Setenv("BP_TOMEE_DISTRIBUTION", "microprofile")).To(Succeed())
+
+		t.Setenv("BP_ARCH", "amd64")
 	})
 
 	it.After(func() {


### PR DESCRIPTION
## Summary
When running `syft`, do not use effect.NewExecutor which runs the command with a tty. This seems to cause an issue with syft (or possibly with our tty library pty), and in either case you end up with stray formatting characters even though we tell syft to be quiet. Using CommandExecutor is basically the same, but it doesn't run with a tty.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
