### PR TITLE
Make the home layer a cache one

### DIFF
--- a/tomee/home.go
+++ b/tomee/home.go
@@ -33,6 +33,7 @@ type Home struct {
 
 func NewHome(dependency libpak.BuildpackDependency, cache libpak.DependencyCache) (Home, libcnb.BOMEntry) {
 	contrib, entry := libpak.NewDependencyLayer(dependency, cache, libcnb.LayerTypes{
+		Cache:  true,
 		Launch: true,
 	})
 	return Home{LayerContributor: contrib}, entry


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
This follows the [PR](https://github.com/paketo-buildpacks/apache-tomee/pull/318) for introducing `BPI_TOMCAT_ADDITIONAL_COMMON_JARS`
In order for the mechanism to work `catalina.properties` file should be copied to `catalina.base/conf` and altered. It is copied from the `home` layer where the corresponding TomEE distribution specified is downloaded and expanded to. In certain situations when on subsequent builds the `home` layer is being reused:
<img width="1124" height="124" alt="image" src="https://github.com/user-attachments/assets/8b6f33c2-1056-4e13-98ab-b62311dd5966" />
its contents are not available during build while the `base` layer is being constructed and the `catalina.properties` file copying is supposed to be applied. 
In order for the `home` layer to be available in this situation it is marked as a `cache` layer with the corresponding flag.

## Use Cases
Enables the `home` layer to be used as a `cache` layer.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
