### PR TITLE
Switch to using Apache Downloads CDN

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -33,7 +33,7 @@ dependencies:
   version_pattern: "10\\.[\\d]+\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/tomee-dependency:main
   with:
-    uri: https://archive.apache.org/dist/tomee
+    uri: https://downloads.apache.org/tomee
     dist: microprofile
     major: 10
 - name:            Tomee 9 Webprofile
@@ -49,7 +49,7 @@ dependencies:
   version_pattern: "10\\.[\\d]+\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/tomee-dependency:main
   with:
-    uri: https://archive.apache.org/dist/tomee
+    uri: https://downloads.apache.org/tomee
     dist: webprofile
     major: 10
 - name:            Tomee 9 Plus
@@ -65,7 +65,7 @@ dependencies:
   version_pattern: "10\\.[\\d]+\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/tomee-dependency:main
   with:
-    uri: https://archive.apache.org/dist/tomee
+    uri: https://downloads.apache.org/tomee
     dist: plus
     major: 10
 - name:            Tomee 9 Plume
@@ -81,7 +81,7 @@ dependencies:
   version_pattern: "10\\.[\\d]+\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/tomee-dependency:main
   with:
-    uri: https://archive.apache.org/dist/tomee
+    uri: https://downloads.apache.org/tomee
     dist: plume
     major: 10
 

--- a/.github/workflows/pb-update-tomee-10-microprofile.yml
+++ b/.github/workflows/pb-update-tomee-10-microprofile.yml
@@ -29,7 +29,7 @@ jobs:
               with:
                 dist: microprofile
                 major: 10
-                uri: https://archive.apache.org/dist/tomee
+                uri: https://downloads.apache.org/tomee
             - name: Update Buildpack Dependency
               id: buildpack
               run: |

--- a/.github/workflows/pb-update-tomee-10-plume.yml
+++ b/.github/workflows/pb-update-tomee-10-plume.yml
@@ -29,7 +29,7 @@ jobs:
               with:
                 dist: plume
                 major: 10
-                uri: https://archive.apache.org/dist/tomee
+                uri: https://downloads.apache.org/tomee
             - name: Update Buildpack Dependency
               id: buildpack
               run: |

--- a/.github/workflows/pb-update-tomee-10-plus.yml
+++ b/.github/workflows/pb-update-tomee-10-plus.yml
@@ -29,7 +29,7 @@ jobs:
               with:
                 dist: plus
                 major: 10
-                uri: https://archive.apache.org/dist/tomee
+                uri: https://downloads.apache.org/tomee
             - name: Update Buildpack Dependency
               id: buildpack
               run: |

--- a/.github/workflows/pb-update-tomee-10-webprofile.yml
+++ b/.github/workflows/pb-update-tomee-10-webprofile.yml
@@ -29,7 +29,7 @@ jobs:
               with:
                 dist: webprofile
                 major: 10
-                uri: https://archive.apache.org/dist/tomee
+                uri: https://downloads.apache.org/tomee
             - name: Update Buildpack Dependency
               id: buildpack
               run: |


### PR DESCRIPTION
## Summary

The Apache Archive has become increasingly slow. This switches to using the Downloads CDN for Tomee 10. The caveat for using Downloads is that it only has the most recent version, so buildpacks generated with these URLs will not work after the downloads have been moved off of the CDN to archives.apache.org. There is a fix for that though, and it will be documented shortly.

## Use Cases

Faster downloads.